### PR TITLE
opentelemetry-instrumentation-weaviate 0.49.6 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-weaviate" %}
-{% set version = "0.47.2" %}
+{% set version = "0.49.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: f5e9ada6108153a8fac01d492e6593b36c385b7ae328b6bea80da452ce2714ea
+  sha256: e3fe2ca12dcdfadef4e9fa5371ed98a617aaef3399cd00b9d7e72d6986c2467a
 
 build:
   number: 0
@@ -21,9 +21,9 @@ requirements:
     - poetry-core
   run:
     - python
-    - opentelemetry-api >=1.28.0,<2.0.0
-    - opentelemetry-instrumentation >=0.50b0
-    - opentelemetry-semantic-conventions >=0.50b0
+    - opentelemetry-api >=1.38.0,<2.0.0
+    - opentelemetry-instrumentation >=0.59b0
+    - opentelemetry-semantic-conventions >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5
   run_constrained:
     - weaviate-client >=3.26,<5.0


### PR DESCRIPTION
opentelemetry-instrumentation-weaviate 0.49.6 

**Destination channel:** Defaults

### Links

- [PKG-11141]
- dev_url:        https://github.com/traceloop/openllmetry/tree/0.49.6
- conda_forge:    https://github.com/conda-forge/opentelemetry-instrumentation-weaviate-feedstock
- pypi:           https://pypi.org/project/opentelemetry-instrumentation-weaviate/0.49.6
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-instrumentation-weaviate/0.49.6

### Explanation of changes:

- new version number


[PKG-11141]: https://anaconda.atlassian.net/browse/PKG-11141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ